### PR TITLE
On signup, pass user as data vs. user (to avoid creating in intercom.)

### DIFF
--- a/_site/public/js/app.js
+++ b/_site/public/js/app.js
@@ -25,8 +25,7 @@ function trackSignUp(user) {
     data: JSON.stringify({
       category: 'Onboard',
       action: 'signup',
-      user: {
-        id: user.id,
+      data: {
         name: user.name,
         email: user.email
       }


### PR DESCRIPTION
@coreylight 

Found a bug where McMahon was still passing the signup object as user to Myst, which was creating the signup as a user in Intercom. 

This passes the signup's name & email as data instead, which will get stringified as the label in GA (and won't show up in Intercom at all). 
