### PR TITLE
`exit 0` on missing tests for McMahon master

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "repository": "",
   "author": "Opsee Team",


### PR DESCRIPTION
I added Circle integration on the v2 branch, but it fails on master 'cuz of the default `exit 1` in package.json. Annoying. 
