### PR TITLE
Track events with GA instead of Myst

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
     connect: {
       server: {
         options: {
-          port: 4000,
+          port: 8080,
           livereload:35728,
           base:'dist'
         }
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
     },
     open:{
       dev:{
-        path:'http://localhost:4000'
+        path:'http://localhost:8080'
       }
     },
     copy:{

--- a/_site/public/js/app.js
+++ b/_site/public/js/app.js
@@ -1,4 +1,3 @@
-var MYST_API = 'https://myst.opsee.com';
 var AUTH_API = 'https://auth.opsee.com';
 
 /**
@@ -30,18 +29,6 @@ function trackSignUp(user) {
   };
 
   window.ga('send', 'event', category, action, JSON.stringify(data));
-
-  return $.ajax({
-    type: 'POST',
-    url: MYST_API + '/event',
-    data: JSON.stringify({
-      category,
-      action,
-      data
-    }),
-    contentType: 'application/json; charset=utf-8',
-    dataType: 'json'
-  });
 }
 
 $( document ).ready(function() {


### PR DESCRIPTION
So that we can retain browser context (document referrer, etc.)

Should be deployed with opsee/myst#33 and https://github.com/opsee/emissary/pull/186

@coreylight fyi
